### PR TITLE
Revert to status branch mk.2

### DIFF
--- a/Source/GitSourceControl/GitSourceControl.Build.cs
+++ b/Source/GitSourceControl/GitSourceControl.Build.cs
@@ -21,7 +21,8 @@ public class GitSourceControl : ModuleRules
 				"UnrealEd",
 				"SourceControl",
 				"SourceControlWindows",
-				"Projects"
+				"Projects",
+				"Engine",
 			}
 		);
 

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -101,8 +101,11 @@ bool FGitSourceControlMenu::CanCommit() const
 {
 	// The 'Submit Content' operation could lead to a world reload (in UEFN) that takes the user out of their selected editor mode.
 	// Piggy back on the 'CanAutoSave' functionality to determine if now is a good time to trigger a 'Submit Content' SCC operation.
-
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
 	return GLevelEditorModeTools().CanAutoSave() && FSourceControlWindows::CanChoosePackagesToCheckIn();
+#else
+	return true;
+#endif
 }
 
 /// Prompt to save or discard all packages

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -202,11 +202,11 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 	);
 
 	const FString WorldAssetName = UWorld::StaticClass()->GetName();
-	const bool bAssetsContainsLevel = SelectedAssets.ContainsByPredicate([&WorldAssetName](const FAssetData& AssetData)
+	const bool bSelectedAssetsContainsWorld = SelectedAssets.ContainsByPredicate([&WorldAssetName](const FAssetData& AssetData)
 	{
 		return AssetData.AssetClassPath.GetAssetName() == WorldAssetName;
 	});
-	const bool bCanRevertToStatusBranch = !bAssetsContainsLevel;
+	const bool bCanRevertToStatusBranch = !bSelectedAssetsContainsWorld;
 
 	MenuBuilder.AddMenuEntry(
 		FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -204,9 +204,9 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 		FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
 		FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Diff"),
+		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
 #else
-		FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Diff"),
+		FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
 #endif
 		FUIAction(FExecuteAction::CreateLambda([SelectedAssets, BranchName]
 		{

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -219,10 +219,16 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 		FUIAction(
 			FExecuteAction::CreateLambda([SelectedAssets, BranchName]
 			{
-			   const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
-			   const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
-			   const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
-			   GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
+				const FText Message = FText::Format(LOCTEXT("StatusRevertAskForConfirmation", "Are you sure you want to revert the selected files to status branch {0}"), FText::FromString(BranchName));
+				const EAppReturnType::Type ConfirmationAnswer = FMessageDialog::Open(EAppMsgCategory::Warning, EAppMsgType::YesNoCancel, Message);
+
+				if (ConfirmationAnswer == EAppReturnType::Yes)
+				{
+					const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
+					const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
+					const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
+					GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
+				}
 			}),
 			FCanExecuteAction::CreateLambda([bCanRevertToStatusBranch]
 			{

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -22,6 +22,7 @@
 #include "GitSourceControlUtils.h"
 #include "ISourceControlModule.h"
 #include "SourceControlHelpers.h"
+#include "Engine/World.h"
 #include "Framework/Commands/UIAction.h"
 #include "Framework/MultiBox/MultiBoxExtender.h"
 #include "Framework/MultiBox/MultiBoxBuilder.h"
@@ -200,9 +201,10 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 		FUIAction(FExecuteAction::CreateRaw( this, &FGitSourceControlModule::DiffAssetAgainstGitOriginBranch, SelectedAssets, BranchName ))
 	);
 
-	const bool bAssetsContainsLevel = SelectedAssets.ContainsByPredicate([](const FAssetData& AssetData)
+	const FString WorldAssetName = UWorld::StaticClass()->GetName();
+	const bool bAssetsContainsLevel = SelectedAssets.ContainsByPredicate([&WorldAssetName](const FAssetData& AssetData)
 	{
-		return AssetData.AssetClassPath.GetAssetName() == "World";
+		return AssetData.AssetClassPath.GetAssetName() == WorldAssetName;
 	});
 	const bool bCanRevertToStatusBranch = !bAssetsContainsLevel;
 

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -200,22 +200,31 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 		FUIAction(FExecuteAction::CreateRaw( this, &FGitSourceControlModule::DiffAssetAgainstGitOriginBranch, SelectedAssets, BranchName ))
 	);
 
-	MenuBuilder.AddMenuEntry(
-		FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
-		FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
-#else
-		FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
-#endif
-		FUIAction(FExecuteAction::CreateLambda([SelectedAssets, BranchName]
-		{
-			const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
-			const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
-			const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
-			GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
-		}))
-	);
+	const bool bAssetsContainsLevel = SelectedAssets.ContainsByPredicate([](const FAssetData& AssetData)
+	{
+		return AssetData.AssetClassPath.GetAssetName() == "World";
+	});
+	const bool bCanRevertToStatusBranch = !bAssetsContainsLevel;
+
+	if (bCanRevertToStatusBranch)
+	{
+		MenuBuilder.AddMenuEntry(
+		   FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
+		   FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
+   #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+		   FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
+   #else
+		   FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
+   #endif
+		   FUIAction(FExecuteAction::CreateLambda([SelectedAssets, BranchName]
+		   {
+			   const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
+			   const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
+			   const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
+			   GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
+		   }))
+	   );
+	}
 }
 
 void FGitSourceControlModule::DiffAssetAgainstGitOriginBranch(const TArray<FAssetData> SelectedAssets, FString BranchName) const

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -199,6 +199,23 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 #endif
 		FUIAction(FExecuteAction::CreateRaw( this, &FGitSourceControlModule::DiffAssetAgainstGitOriginBranch, SelectedAssets, BranchName ))
 	);
+
+	MenuBuilder.AddMenuEntry(
+		FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
+		FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Diff"),
+#else
+		FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Diff"),
+#endif
+		FUIAction(FExecuteAction::CreateLambda([SelectedAssets, BranchName]
+		{
+			const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
+			const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
+			const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
+			GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
+		}))
+	);
 }
 
 void FGitSourceControlModule::DiffAssetAgainstGitOriginBranch(const TArray<FAssetData> SelectedAssets, FString BranchName) const

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -208,27 +208,28 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 	});
 	const bool bCanRevertToStatusBranch = !bAssetsContainsLevel;
 
-	if (bCanRevertToStatusBranch)
-	{
-		MenuBuilder.AddMenuEntry(
-			FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
-			FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
-	#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-			FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
-	#else
-			FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
-	#endif
-			FUIAction(
-				FExecuteAction::CreateLambda([SelectedAssets, BranchName]
-				{
-					const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
-					const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
-					const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
-					GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
-				})
-			)
-		);
-	}
+	MenuBuilder.AddMenuEntry(
+		FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
+		FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
+		#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
+		#else
+		FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
+		#endif
+		FUIAction(
+			FExecuteAction::CreateLambda([SelectedAssets, BranchName]
+			{
+			   const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
+			   const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
+			   const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
+			   GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
+			}),
+			FCanExecuteAction::CreateLambda([bCanRevertToStatusBranch]
+			{
+				return bCanRevertToStatusBranch;
+			})
+		)
+	);
 }
 
 void FGitSourceControlModule::DiffAssetAgainstGitOriginBranch(const TArray<FAssetData> SelectedAssets, FString BranchName) const

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -206,26 +206,28 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 	{
 		return AssetData.AssetClassPath.GetAssetName() == WorldAssetName;
 	});
-	
 	const bool bCanRevertToStatusBranch = !bAssetsContainsLevel;
+
 	if (bCanRevertToStatusBranch)
 	{
 		MenuBuilder.AddMenuEntry(
-		   FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
-		   FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
-   #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-		   FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
-   #else
-		   FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
-   #endif
-		   FUIAction(FExecuteAction::CreateLambda([SelectedAssets, BranchName]
-		   {
-			   const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
-			   const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
-			   const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
-			   GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
-		   }))
-	   );
+			FText::Format(LOCTEXT("StatusRevert", "Revert to status branch: {0}"), FText::FromString(BranchName)),
+			FText::Format(LOCTEXT("StatusRevertDesc", "Revert this asset back to its state in status branch: {0}"), FText::FromString(BranchName)),
+	#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+			FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Revert"),
+	#else
+			FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Revert"),
+	#endif
+			FUIAction(
+				FExecuteAction::CreateLambda([SelectedAssets, BranchName]
+				{
+					const FGitSourceControlModule& GitSourceControl = FModuleManager::GetModuleChecked<FGitSourceControlModule>("GitSourceControl");
+					const FString& PathToGitBinary = GitSourceControl.AccessSettings().GetBinaryPath();
+					const FString& PathToRepositoryRoot = GitSourceControl.GetProvider().GetPathToRepositoryRoot();
+					GitSourceControlUtils::SyncAssetsFromBranch(PathToGitBinary, PathToRepositoryRoot, SelectedAssets, BranchName);
+				})
+			)
+		);
 	}
 }
 

--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -206,8 +206,8 @@ void FGitSourceControlModule::CreateGitContentBrowserAssetMenu(FMenuBuilder& Men
 	{
 		return AssetData.AssetClassPath.GetAssetName() == WorldAssetName;
 	});
+	
 	const bool bCanRevertToStatusBranch = !bAssetsContainsLevel;
-
 	if (bCanRevertToStatusBranch)
 	{
 		MenuBuilder.AddMenuEntry(

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1490,9 +1490,9 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 			// which means editor plugins are enabled and running, but they don't run UnrealEdEngine, so the status branches are not initialized.
 			if (StatusBranches.Num() > 0)
 			{
-				// Check if the files state in the branch in which is changed is actually different from status branch
+				// Check if the files state in the branch in which is changed is actually different from compared branch
 				// This opens files for edit if they were modified in another branch but have since been reverted back to state in status.
-				TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("%s..%s"), *StatusBranches[0], *Branch), TEXT(""), TEXT("--") };
+				TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("...%s"), *Branch), TEXT(""), TEXT("--") };
 				const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToDiff, DiffResults, ErrorMessages);
 				// Get the intersection of the 2 containers
 				Intersection = DiffResults.FilterByPredicate([&LogResults](const FString& ChangedFile) { return LogResults.Contains(ChangedFile); });

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2543,25 +2543,18 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 	TArray<FString> DiffResults;
 	TArray<FString> ErrorMessages;
 	TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("HEAD..%s"), *BranchName), TEXT(""), TEXT("--") };
-	const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToSync, DiffResults, ErrorMessages);
-	FilesToSync.RemoveAllSwap([&DiffResults, &InRepositoryRoot](const FString& File)
+	RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToSync, DiffResults, ErrorMessages);
+
+	// DiffResults is repo relative and we need to be
+	// in absolute so we can compare against FilesToSync
+	for (FString& Path : DiffResults)
 	{
-		// * SelectedAssets is a list of paths that are package relative (eg. "Game/...")
-		//   that comes straight from Unreal Engine
-		// * FilesToSync is a list of absolute paths  (eg. "C:/...") that will be passed to git
-		// * DiffResults is a list of paths relative to the git repo (eg. "Project/...")
+		Path = FPaths::ConvertRelativePathToFull(InRepositoryRoot, Path);
+	}
 
-		// We need to minify FilesToSync to only files that match DiffResults so we attempt to
-		// revert only files that have changed. FPaths::MakePathRelativeTo will take an absolute
-		// path and make it relative, but it will include the root folder (eg. The repo root name)
-		// which needs to be stripped for the comparison to work
-		FString RelativeFromRootInclusive = File;
-		FPaths::MakePathRelativeTo(RelativeFromRootInclusive, *InRepositoryRoot);
-
-		FString RelativeFromRoot;
-		RelativeFromRootInclusive.Split("/", nullptr, &RelativeFromRoot);
-
-		return !DiffResults.Contains(RelativeFromRoot);
+	FilesToSync.RemoveAllSwap([&DiffResults](const FString& File)
+	{
+		return !DiffResults.Contains(File);
 	});
 
 	if (!FilesToSync.IsEmpty())

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2555,16 +2555,13 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		// revert only files that have changed. FPaths::MakePathRelativeTo will take an absolute
 		// path and make it relative, but it will include the root folder (eg. The repo root name)
 		// which needs to be stripped for the comparison to work
-		FString RelativePath = File;
-		FPaths::MakePathRelativeTo(RelativePath, *InRepositoryRoot);
+		FString RelativeFromRootInclusive = File;
+		FPaths::MakePathRelativeTo(RelativeFromRootInclusive, *InRepositoryRoot);
 
-		int FindLocation = 0;
-		if (RelativePath.FindChar('/', FindLocation))
-		{
-			// +1 to strip the slash
-			RelativePath = RelativePath.Mid(FindLocation + 1);
-		}
-		return !DiffResults.Contains(RelativePath);
+		FString RelativeFromRoot;
+		RelativeFromRootInclusive.Split("/", nullptr, &RelativeFromRoot);
+
+		return !DiffResults.Contains(RelativeFromRoot);
 	});
 
 	if (!FilesToSync.IsEmpty())

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2634,10 +2634,8 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 
 		if (bOperationSuccess)
 		{
-			FCheckinResultInfo ResultInfo;
-			// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
-			constexpr bool bUseSourceControlStateCache = false;
-			FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
+			FText Message = FText::Format(LOCTEXT("SyncAssetsFromBranchSuccess", "Successfully reverted file(s) to match {0}"), FText::FromString(BranchName));
+			FMessageDialog::Open(EAppMsgCategory::Success, EAppMsgType::Ok, Message);
 		}
 		else
 		{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2536,9 +2536,14 @@ TSharedPtr<ISourceControlRevision, ESPMode::ThreadSafe> GetOriginRevisionOnBranc
 void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, FString BranchName)
 {
 	TArray<FString> FilesToSync;
+	TMap<FString, FString> AbsoluteFilePathToAsset;
 	for (const FAssetData& AssetData : SelectedAssets)
 	{
-		FilesToSync.Add(SourceControlHelpers::PackageFilename(AssetData.PackageName.ToString()));
+		FString PackageName = AssetData.PackageName.ToString();
+		FString AbsoluteFileName = SourceControlHelpers::PackageFilename(PackageName);
+		
+		FilesToSync.Add(AbsoluteFileName);
+		AbsoluteFilePathToAsset.Add(AbsoluteFileName, PackageName);
 	}
 
 	TArray<FString> DiffResults;
@@ -2599,7 +2604,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToLock);
 
 		const bool bOperationSuccess = USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
-			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync, &Provider, &SelectedAssets](const TArray<FString>&)
+			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync, &Provider, &AbsoluteFilePathToAsset](const TArray<FString>&)
 		{
 			// "checkout" in the context of git will download the file whereas "checkout"
 			// in the context of Unreal Engine/Perforce will add a lock and make it writable
@@ -2616,11 +2621,10 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 					UE_LOG(LogSourceControl, Error, TEXT("%s"), *Error);
 				}
 
-				// TODO: Build this by comparing files to sync so we don't try to revert too much
 				TArray<FString> PackagesToRevert;
-				for (const FAssetData& AssetData : SelectedAssets)
+				for (const FString& AbsoluteFilePath : FilesToSync)
 				{
-					PackagesToRevert.Add(AssetData.PackageName.ToString());
+					PackagesToRevert.Add(AbsoluteFilePathToAsset[AbsoluteFilePath]);
 				}
 				auto RevertOperation = ISourceControlOperation::Create<FRevert>();
 				Provider.Execute(RevertOperation, PackagesToRevert, EConcurrency::Synchronous);

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2536,14 +2536,11 @@ TSharedPtr<ISourceControlRevision, ESPMode::ThreadSafe> GetOriginRevisionOnBranc
 void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, const FString& BranchName)
 {
 	TArray<FString> FilesToDiff;
-	TMap<FString, FString> AbsoluteFilePathToAsset;
+
 	for (const FAssetData& AssetData : SelectedAssets)
 	{
-		FString PackageName = AssetData.PackageName.ToString();
-		FString AbsoluteFilePath = SourceControlHelpers::PackageFilename(PackageName);
-		
+		FString AbsoluteFilePath = SourceControlHelpers::PackageFilename(AssetData.PackageName.ToString());		
 		FilesToDiff.Add(AbsoluteFilePath);
-		AbsoluteFilePathToAsset.Add(AbsoluteFilePath, PackageName);
 	}
 
 	TArray<FString> DiffResults;
@@ -2598,7 +2595,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToLock);
 
 		const bool bOperationSuccess = USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
-			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync, &Provider, &AbsoluteFilePathToAsset](const TArray<FString>&)
+			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync](const TArray<FString>&)
 		{
 			// "checkout" in the context of git will download the file whereas "checkout"
 			// in the context of Unreal Engine/Perforce will add a lock and make it writable
@@ -2614,15 +2611,6 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 				{
 					UE_LOG(LogSourceControl, Error, TEXT("%s"), *Error);
 				}
-
-				TArray<FString> PackagesToRevert;
-				for (const FString& AbsoluteFilePath : FilesToSync)
-				{
-					PackagesToRevert.Add(AbsoluteFilePathToAsset[AbsoluteFilePath]);
-				}
-
-				const TSharedRef<FRevert, ESPMode::ThreadSafe> RevertOperation = ISourceControlOperation::Create<FRevert>();
-				Provider.Execute(RevertOperation, PackagesToRevert, EConcurrency::Synchronous);
 			}
 			return bCommandSuccess;
 		});
@@ -2634,7 +2622,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		}
 		else
 		{
-			const FText Message = LOCTEXT("SyncAssetsFromBranchFailedGitCheckout", "Revert To Status Branch failed -  git checkout failed. See the log for details");
+			const FText Message = LOCTEXT("SyncAssetsFromBranchFailedGitCheckout", "Revert To Status Branch failed - git checkout failed. See the log for details and carefully review all files");
 			FMessageDialog::Open(EAppMsgCategory::Error, EAppMsgType::Ok, Message);
 		}
 	}

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2598,21 +2598,39 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 
 		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
 
-		USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
+		const bool bOperationSuccess = USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
 			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync](const TArray<FString>&)
 		{
 			// "checkout" in the context of git will download the file whereas "checkout"
 			// in the context of Unreal Engine/Perforce will add a lock and make it writable
 			TArray<FString> Results;
 			TArray<FString> Errors;
-			RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
-			return true;
+			const FString GitCommand = TEXT("checkout");
+			const bool bCommandSuccess = RunCommand(GitCommand, InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
+
+			if (!bCommandSuccess)
+			{
+				UE_LOG(LogSourceControl, Error, TEXT("Git command %s failed"), *GitCommand);
+				for (const auto& Error : Errors)
+				{
+					UE_LOG(LogSourceControl, Error, TEXT("%s"), *Error);
+				}
+			}
+			return bCommandSuccess;
 		});
 
-		FCheckinResultInfo ResultInfo;
-		// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
-		bool bUseSourceControlStateCache = false;
-		FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
+		if (bOperationSuccess)
+		{
+			FCheckinResultInfo ResultInfo;
+			// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
+			bool bUseSourceControlStateCache = false;
+			FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
+		}
+		else
+		{
+			const FText Message = LOCTEXT("FailedBranchSyncGitCheckout", "Revert To Status Branch failed -  git checkout failed. See the log for details");
+			FMessageDialog::Open(EAppMsgType::Ok, Message);
+		}
 	}
 	else
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -43,6 +43,9 @@
 #include "Async/Async.h"
 #include "UObject/Linker.h"
 
+#include "SourceControlHelpers.h"
+#include "SourceControlWindows.h"
+
 #ifndef GIT_DEBUG_STATUS
 #define GIT_DEBUG_STATUS 0
 #endif
@@ -2527,6 +2530,36 @@ TSharedPtr<ISourceControlRevision, ESPMode::ThreadSafe> GetOriginRevisionOnBranc
 	}
 
 	return nullptr;
+}
+
+void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, FString BranchName)
+{
+	TArray<FString> FilesToSync;
+	for (const FAssetData& AssetData : SelectedAssets)
+	{
+		FilesToSync.Add(SourceControlHelpers::PackageFilename(AssetData.PackageName.ToString()));
+	}
+
+	// Source control checkout is lock the file and mark for read.
+	FGitSourceControlModule* GitSourceControl = FGitSourceControlModule::GetThreadSafe();
+	if (!GitSourceControl)
+	{
+		return;
+	}
+	FGitSourceControlProvider& Provider = GitSourceControl->GetProvider();
+	Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
+
+	// Git checkout is pulling content
+	TArray<FString> Results;
+	TArray<FString> Errors;
+	RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
+
+
+	FCheckinResultInfo ResultInfo;
+	// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
+	bool bUseSourceControlStateCache = false;
+	FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
+
 }
 
 } // namespace GitSourceControlUtils

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2623,7 +2623,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		{
 			FCheckinResultInfo ResultInfo;
 			// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
-			bool bUseSourceControlStateCache = false;
+			constexpr bool bUseSourceControlStateCache = false;
 			FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
 		}
 		else

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2596,7 +2596,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 			return;
 		}
 
-		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
+		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToLock);
 
 		const bool bOperationSuccess = USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
 			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync](const TArray<FString>&)

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2591,7 +2591,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		if (UneditableAssets.Num() != 0)
 		{
 			FString JoinedFiles = FString::Join(UneditableAssets, TEXT("\n"));
-			FMessageDialog::Open(EAppMsgType::Ok, FText::Format(LOCTEXT("FailedBranchSync", "Failed to sync file from branch {0} because the following files cannot be checked out \n{1}"), { FText::FromString(BranchName), FText::FromString(JoinedFiles) }));
+			FMessageDialog::Open(EAppMsgCategory::Error, EAppMsgType::Ok, FText::Format(LOCTEXT("FailedBranchSync", "Failed to sync file from branch {0} because the following files cannot be checked out \n{1}"), { FText::FromString(BranchName), FText::FromString(JoinedFiles) }));
 			return;
 		}
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2599,14 +2599,14 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToLock);
 
 		const bool bOperationSuccess = USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
-			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync](const TArray<FString>&)
+			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync, &Provider, &SelectedAssets](const TArray<FString>&)
 		{
 			// "checkout" in the context of git will download the file whereas "checkout"
 			// in the context of Unreal Engine/Perforce will add a lock and make it writable
 			TArray<FString> Results;
 			TArray<FString> Errors;
 			const FString GitCommand = TEXT("checkout");
-			const bool bCommandSuccess = RunCommand(GitCommand, InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
+			bool bCommandSuccess = RunCommand(GitCommand, InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
 
 			if (!bCommandSuccess)
 			{
@@ -2615,6 +2615,15 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 				{
 					UE_LOG(LogSourceControl, Error, TEXT("%s"), *Error);
 				}
+
+				// TODO: Build this by comparing files to sync so we don't try to revert too much
+				TArray<FString> PackagesToRevert;
+				for (const FAssetData& AssetData : SelectedAssets)
+				{
+					PackagesToRevert.Add(AssetData.PackageName.ToString());
+				}
+				auto RevertOperation = ISourceControlOperation::Create<FRevert>();
+				Provider.Execute(RevertOperation, PackagesToRevert, EConcurrency::Synchronous);
 			}
 			return bCommandSuccess;
 		});

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2540,10 +2540,10 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 	for (const FAssetData& AssetData : SelectedAssets)
 	{
 		FString PackageName = AssetData.PackageName.ToString();
-		FString AbsoluteFileName = SourceControlHelpers::PackageFilename(PackageName);
+		FString AbsoluteFilePath = SourceControlHelpers::PackageFilename(PackageName);
 		
-		FilesToSync.Add(AbsoluteFileName);
-		AbsoluteFilePathToAsset.Add(AbsoluteFileName, PackageName);
+		FilesToSync.Add(AbsoluteFilePath);
+		AbsoluteFilePathToAsset.Add(AbsoluteFilePath, PackageName);
 	}
 
 	TArray<FString> DiffResults;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2533,7 +2533,7 @@ TSharedPtr<ISourceControlRevision, ESPMode::ThreadSafe> GetOriginRevisionOnBranc
 	return nullptr;
 }
 
-void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, FString BranchName)
+void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, const FString& BranchName)
 {
 	TArray<FString> FilesToSync;
 	TMap<FString, FString> AbsoluteFilePathToAsset;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2544,10 +2544,28 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 	TArray<FString> ErrorMessages;
 	TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("HEAD..%s"), *BranchName), TEXT(""), TEXT("--") };
 	const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToSync, DiffResults, ErrorMessages);
-	FilesToSync.RemoveAllSwap([&DiffResults](const FString& File)
+	FilesToSync.RemoveAllSwap([&DiffResults, &InRepositoryRoot](const FString& File)
+	{
+		// * SelectedAssets is a list of paths that are package relative (eg. "Game/...")
+		//   that comes straight from Unreal Engine
+		// * FilesToSync is a list of absolute paths  (eg. "C:/...") that will be passed to git
+		// * DiffResults is a list of paths relative to the git repo (eg. "Project/...")
+
+		// We need to minify FilesToSync to only files that match DiffResults so we attempt to
+		// revert only files that have changed. FPaths::MakePathRelativeTo will take an absolute
+		// path and make it relative, but it will include the root folder (eg. The repo root name)
+		// which needs to be stripped for the comparison to work
+		FString RelativePath = File;
+		FPaths::MakePathRelativeTo(RelativePath, *InRepositoryRoot);
+
+		int FindLocation = 0;
+		if (RelativePath.FindChar('/', FindLocation))
 		{
-			return !DiffResults.Contains(File);
-		});
+			// +1 to strip the slash
+			RelativePath = RelativePath.Mid(FindLocation + 1);
+		}
+		return !DiffResults.Contains(RelativePath);
+	});
 
 	if (!FilesToSync.IsEmpty())
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2639,13 +2639,13 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		}
 		else
 		{
-			const FText Message = LOCTEXT("FailedBranchSyncGitCheckout", "Revert To Status Branch failed -  git checkout failed. See the log for details");
-			FMessageDialog::Open(EAppMsgType::Ok, Message);
+			const FText Message = LOCTEXT("SyncAssetsFromBranchFailedGitCheckout", "Revert To Status Branch failed -  git checkout failed. See the log for details");
+			FMessageDialog::Open(EAppMsgCategory::Error, EAppMsgType::Ok, Message);
 		}
 	}
 	else
 	{
-		FMessageDialog::Open(EAppMsgType::Ok, (LOCTEXT("BranchSyncUnchanged", "Failed to sync files because the selected file(s) were unchanged")));
+		FMessageDialog::Open(EAppMsgCategory::Info, EAppMsgType::Ok, LOCTEXT("SyncAssetsFromBranchAssetsUnchanged", "Failed to sync files because the selected file(s) were unchanged"));
 	}
 }
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2597,10 +2597,14 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 
 		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
 
-		// Git checkout is pulling content
-		TArray<FString> Results;
-		TArray<FString> Errors;
-		RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
+		USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync, [&](const TArray<FString>&)
+		{
+			// Git checkout is pulling content
+			TArray<FString> Results;
+			TArray<FString> Errors;
+			RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
+			return true;
+		});
 
 		FCheckinResultInfo ResultInfo;
 		// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2598,7 +2598,8 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 
 		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
 
-		USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync, [&](const TArray<FString>&)
+		USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
+			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync](const TArray<FString>&)
 		{
 			// Git checkout is pulling content
 			TArray<FString> Results;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -44,6 +44,7 @@
 #include "UObject/Linker.h"
 
 #include "SourceControlHelpers.h"
+#include "SourceControlOperations.h"
 #include "SourceControlWindows.h"
 
 #ifndef GIT_DEBUG_STATUS

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2620,7 +2620,8 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 				{
 					PackagesToRevert.Add(AbsoluteFilePathToAsset[AbsoluteFilePath]);
 				}
-				auto RevertOperation = ISourceControlOperation::Create<FRevert>();
+
+				const TSharedRef<FRevert, ESPMode::ThreadSafe> RevertOperation = ISourceControlOperation::Create<FRevert>();
 				Provider.Execute(RevertOperation, PackagesToRevert, EConcurrency::Synchronous);
 			}
 			return bCommandSuccess;

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2553,10 +2553,7 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 
 	// DiffResults is repo relative and we need to be
 	// in absolute so we can compare against FilesToSync
-	for (FString& Path : DiffResults)
-	{
-		Path = FPaths::ConvertRelativePathToFull(InRepositoryRoot, Path);
-	}
+	AbsoluteFilenames(InRepositoryRoot, DiffResults);
 
 	FilesToSync.RemoveAllSwap([&DiffResults](const FString& File)
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2535,30 +2535,27 @@ TSharedPtr<ISourceControlRevision, ESPMode::ThreadSafe> GetOriginRevisionOnBranc
 
 void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, const FString& BranchName)
 {
-	TArray<FString> FilesToSync;
+	TArray<FString> FilesToDiff;
 	TMap<FString, FString> AbsoluteFilePathToAsset;
 	for (const FAssetData& AssetData : SelectedAssets)
 	{
 		FString PackageName = AssetData.PackageName.ToString();
 		FString AbsoluteFilePath = SourceControlHelpers::PackageFilename(PackageName);
 		
-		FilesToSync.Add(AbsoluteFilePath);
+		FilesToDiff.Add(AbsoluteFilePath);
 		AbsoluteFilePathToAsset.Add(AbsoluteFilePath, PackageName);
 	}
 
 	TArray<FString> DiffResults;
 	TArray<FString> ErrorMessages;
 	TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("HEAD..%s"), *BranchName), TEXT(""), TEXT("--") };
-	RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToSync, DiffResults, ErrorMessages);
+	RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToDiff, DiffResults, ErrorMessages);
 
 	// DiffResults is repo relative and we need to be
 	// in absolute so we can compare against FilesToSync
 	AbsoluteFilenames(InRepositoryRoot, DiffResults);
 
-	FilesToSync.RemoveAllSwap([&DiffResults](const FString& File)
-	{
-		return !DiffResults.Contains(File);
-	});
+	const TArray<FString> FilesToSync = DiffResults;
 
 	if (!FilesToSync.IsEmpty())
 	{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2540,27 +2540,71 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		FilesToSync.Add(SourceControlHelpers::PackageFilename(AssetData.PackageName.ToString()));
 	}
 
-	// Source control checkout is lock the file and mark for read.
-	FGitSourceControlModule* GitSourceControl = FGitSourceControlModule::GetThreadSafe();
-	if (!GitSourceControl)
+	TArray<FString> DiffResults;
+	TArray<FString> ErrorMessages;
+	TArray<FString> DiffParametersLog{ TEXT("--pretty="), TEXT("--name-only"), FString::Printf(TEXT("HEAD..%s"), *BranchName), TEXT(""), TEXT("--") };
+	const bool bResultDiff = RunCommand(TEXT("diff"), InPathToGitBinary, InRepositoryRoot, DiffParametersLog, FilesToSync, DiffResults, ErrorMessages);
+	FilesToSync.RemoveAllSwap([&DiffResults](const FString& File)
+		{
+			return !DiffResults.Contains(File);
+		});
+
+	if (!FilesToSync.IsEmpty())
 	{
-		return;
+		// Source control checkout is lock the file and mark for read.
+		FGitSourceControlModule* GitSourceControl = FGitSourceControlModule::GetThreadSafe();
+		if (!GitSourceControl)
+		{
+			return;
+		}
+		FGitSourceControlProvider& Provider = GitSourceControl->GetProvider();
+
+		TArray<FString> FilesToLock;
+		TArray<FString> UneditableAssets;
+
+		TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> OutStates;
+		Provider.GetState(FilesToSync, OutStates, EStateCacheUsage::ForceUpdate);
+
+		FString FilePath;
+		for (const auto& SourceControlState : OutStates)
+		{
+			FilePath = SourceControlState->GetFilename();
+			if (SourceControlState->CanCheckout())
+			{
+				FilesToLock.Add(FilePath);
+			}
+			else if (!SourceControlState->IsCheckedOut())
+			{
+				UE_LOG(LogSourceControl, Warning, TEXT("File %s is not checked out, and cannot be checked out - failed to sync."), *FilePath);
+				UneditableAssets.Add(FilePath);
+			}
+		}
+
+		if (UneditableAssets.Num() != 0)
+		{
+			FString JoinedFiles = FString::Join(UneditableAssets, TEXT("\n"));
+			FMessageDialog::Open(EAppMsgType::Ok, FText::Format(LOCTEXT("FailedBranchSync", "Failed to sync file from branch {0} because the following files cannot be checked out \n{1}"), { FText::FromString(BranchName), FText::FromString(JoinedFiles) }));
+			return;
+		}
+
+		Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
+
+		// Git checkout is pulling content
+		TArray<FString> Results;
+		TArray<FString> Errors;
+		RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
+
+		FCheckinResultInfo ResultInfo;
+		// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
+		bool bUseSourceControlStateCache = false;
+		FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
 	}
-	FGitSourceControlProvider& Provider = GitSourceControl->GetProvider();
-	Provider.Execute(ISourceControlOperation::Create<FCheckOut>(), FilesToSync);
-
-	// Git checkout is pulling content
-	TArray<FString> Results;
-	TArray<FString> Errors;
-	RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);
-
-
-	FCheckinResultInfo ResultInfo;
-	// Re-check the status of the files before opening the window because we've just reverted a bunch of files which haven't had a status update yet.
-	bool bUseSourceControlStateCache = false;
-	FSourceControlWindows::PromptForCheckin(ResultInfo, FilesToSync, TArray<FString>(), TArray<FString>(), bUseSourceControlStateCache);
-
+	else
+	{
+		FMessageDialog::Open(EAppMsgType::Ok, (LOCTEXT("BranchSyncUnchanged", "Failed to sync files because the selected file(s) were unchanged")));
+	}
 }
+
 
 } // namespace GitSourceControlUtils
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2601,7 +2601,8 @@ void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRep
 		USourceControlHelpers::ApplyOperationAndReloadPackages(FilesToSync,
 			[&InPathToGitBinary, &InRepositoryRoot, &BranchName, &FilesToSync](const TArray<FString>&)
 		{
-			// Git checkout is pulling content
+			// "checkout" in the context of git will download the file whereas "checkout"
+			// in the context of Unreal Engine/Perforce will add a lock and make it writable
 			TArray<FString> Results;
 			TArray<FString> Errors;
 			RunCommand("checkout", InPathToGitBinary, InRepositoryRoot, { BranchName, TEXT("--") }, FilesToSync, Results, Errors);

--- a/Source/GitSourceControl/Public/GitSourceControlMenu.h
+++ b/Source/GitSourceControl/Public/GitSourceControlMenu.h
@@ -32,8 +32,9 @@ protected:
 
 private:
 	bool HaveRemoteUrl() const;
+	bool CanCommit() const;
 
-	bool				SaveDirtyPackages();
+	bool SaveDirtyPackages();
 
 	bool StashAwayAnyModifications();
 	void ReApplyStashedModifications();

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -387,6 +387,6 @@ bool PullOrigin(const FString& InPathToGitBinary, const FString& InPathToReposit
 
 GITSOURCECONTROL_API TSharedPtr< class ISourceControlRevision, ESPMode::ThreadSafe > GetOriginRevisionOnBranch( const FString & InPathToGitBinary, const FString & InRepositoryRoot, const FString & InRelativeFileName, TArray< FString > & OutErrorMessages, const FString & BranchName );
 
-void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, FString BranchName);
+void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, const FString& BranchName);
 
 }

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -387,4 +387,6 @@ bool PullOrigin(const FString& InPathToGitBinary, const FString& InPathToReposit
 
 GITSOURCECONTROL_API TSharedPtr< class ISourceControlRevision, ESPMode::ThreadSafe > GetOriginRevisionOnBranch( const FString & InPathToGitBinary, const FString & InRepositoryRoot, const FString & InRelativeFileName, TArray< FString > & OutErrorMessages, const FString & BranchName );
 
+void SyncAssetsFromBranch(const FString& InPathToGitBinary, const FString& InRepositoryRoot, const TArray<FAssetData>& SelectedAssets, FString BranchName);
+
 }


### PR DESCRIPTION
Re-branching due to incorrectly merging the wrong dev branch in.

This change will add a "Rever to Status Branch" option to the UEGitPlugin. The purpose is that you can select any file which has been pushed to Git and revert it back to what is in in the Status Branch (eg. Main) if you no longer wanted the changes anymore. We are adding it to the plugin for a significant usability improvement due to the current workflow being "download the file from the repo directly, lock the file, replace the file, commit and push the file"