### PR TITLE
Fix some errors on shutdown

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1465,6 +1465,12 @@ bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallb
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(GitSourceControlUtils::RefreshLocks);
 
+	const FGitSourceControlModule* GitSourceControlModule = FGitSourceControlModule::GetThreadSafe();
+	if (GitSourceControlModule == nullptr)
+	{
+		return false;
+	}
+
 	// Refresh could be called from multiple threads concurrently
 	// The NewLocks static here gets swapped with our locks cache, this is a static and not a member to avoid unnecessary allocations
 	// in large projects utilizing OFPA, the locks list could be potentially thousands of pairs of strings that get allocated and de-allocated every time we call this function
@@ -1494,7 +1500,7 @@ bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallb
 			}
 		}
 
-		const FString& LfsUserName = FGitSourceControlModule::Get().GetProvider().GetLockUser();
+		const FString& LfsUserName = GitSourceControlModule->GetProvider().GetLockUser();
 
 		for (const FString& Result : Results)
 		{

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1470,6 +1470,8 @@ bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallb
 	{
 		return false;
 	}
+	
+	const FString& LfsUserName = GitSourceControlModule->GetProvider().GetLockUser();
 
 	// Refresh could be called from multiple threads concurrently
 	// The NewLocks static here gets swapped with our locks cache, this is a static and not a member to avoid unnecessary allocations
@@ -1499,8 +1501,6 @@ bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallb
 				State.Value.LockState = ELockState::NotLocked;
 			}
 		}
-
-		const FString& LfsUserName = GitSourceControlModule->GetProvider().GetLockUser();
 
 		for (const FString& Result : Results)
 		{
@@ -1609,6 +1609,8 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 	{
 		return false;
 	};
+	
+	FGitSourceControlProvider& provider = GitSourceControlModule->GetProvider();
 
 	// Remove files that aren't in the repository
 	const TArray<FString>& RepoFiles = InFiles.FilterByPredicate([InRepositoryRoot](const FString& File) { return File.StartsWith(InRepositoryRoot); });
@@ -1645,7 +1647,6 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 	// Unless somebody used a force push, but that edge case isn't worth the increased cost of running these status updates.
 	// NB:	It is important to still update the local status, as saving files doesn't mark them as modified in source control
 	//		The engine relies on this status update to update the file to reflect that it is modified
-	FGitSourceControlProvider& provider = GitSourceControlModule->GetProvider();
 	TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> States;
 	provider.GetState(InFiles, States, EStateCacheUsage::Use);
 

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1604,6 +1604,12 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(GitSourceControlUtils::RunUpdateStatus);
 
+	FGitSourceControlModule* GitSourceControlModule = FGitSourceControlModule::GetThreadSafe();
+	if (GitSourceControlModule == nullptr)
+	{
+		return false;
+	};
+
 	// Remove files that aren't in the repository
 	const TArray<FString>& RepoFiles = InFiles.FilterByPredicate([InRepositoryRoot](const FString& File) { return File.StartsWith(InRepositoryRoot); });
 
@@ -1639,7 +1645,7 @@ bool RunUpdateStatus(const FString& InPathToGitBinary, const FString& InReposito
 	// Unless somebody used a force push, but that edge case isn't worth the increased cost of running these status updates.
 	// NB:	It is important to still update the local status, as saving files doesn't mark them as modified in source control
 	//		The engine relies on this status update to update the file to reflect that it is modified
-	FGitSourceControlProvider& provider = FGitSourceControlModule::Get().GetProvider();
+	FGitSourceControlProvider& provider = GitSourceControlModule->GetProvider();
 	TArray<TSharedRef<ISourceControlState, ESPMode::ThreadSafe>> States;
 	provider.GetState(InFiles, States, EStateCacheUsage::Use);
 


### PR DESCRIPTION
One error on shutdown that we are running into frequently is when git threads are running in the baackground and they attempt to access data from the GitModule. This access will attempt to get the module but if it isn't loaded it will try to load it. This causes an error because we don't allow the module to be loaded off the main thread. It isn't loaded because it has been unloaded due to editor shutdown.

Origin has "fixed" this by adding a bunch of thread safe get accessors which will get only and no load. If we returned no module then stop doing whatever operation you are doing. I have propagated that pattern into functions that reproduced the crash locally.

More details also exist in this ticket: https://thethreethousands.atlassian.net/browse/TECH-142