### PR TITLE
Fix some cases where files wouldn't update to the correct state

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlModule.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlModule.cpp
@@ -63,7 +63,6 @@ void FGitSourceControlModule::StartupModule()
 	GitSourceControlProvider.RegisterWorker( "MoveToChangelist", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitMoveToChangelistWorker> ) );
 	GitSourceControlProvider.RegisterWorker( "UpdateChangelistsStatus", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitUpdateStagingWorker> ) );
 #endif
-	GitSourceControlProvider.RegisterWorker( "RefreshLocks", FGetGitSourceControlWorker::CreateStatic( &CreateWorker<FGitRefreshLockStateWorker> ) );
 
 	// load our settings
 	GitSourceControlSettings.LoadSettings();

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -384,11 +384,19 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 			InCommand.bCommandSuccessful = true;
 		}
 
-		// git-lfs: unlock files
-		if (InCommand.bUsingGitLfsLocking)
+		if (InCommand.bCommandSuccessful)
 		{
-			// If we successfully pushed (or didn't need to push), unlock the files marked for check in
-			if (InCommand.bCommandSuccessful)
+			for (const auto& File : InCommand.Files)
+			{
+				FGitState& State = States.FindOrAdd(File);
+				State.TreeState = ETreeState::Unmodified;
+				State.RemoteState = ERemoteState::Unset;
+				State.LockState = ELockState::NotLocked;
+				State.LockUser = "";
+			}
+
+			// git-lfs: unlock files
+			if (InCommand.bUsingGitLfsLocking)
 			{
 				// unlock files: execute the LFS command on relative filenames
 				// (unlock only locked files, that is, not Added files)
@@ -402,18 +410,12 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 					{
 						// Not strictly necessary to succeed, so don't update command success
 						const bool bUnlockSuccess = GitSourceControlUtils::RunLFSCommand(TEXT("unlock"), InCommand.PathToGitRoot, InCommand.PathToGitBinary,
-																						 FGitSourceControlModule::GetEmptyStringArray(), FilesToUnlock,
-																						 InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
-						if (bUnlockSuccess)
+							FGitSourceControlModule::GetEmptyStringArray(), FilesToUnlock,
+							InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
+
+						if (!bUnlockSuccess)
 						{
-							for (const auto& File : LockedFiles)
-							{
-								FGitState& State = States.FindOrAdd(File);
-								State.TreeState = ETreeState::Unmodified;
-								State.RemoteState = ERemoteState::Unset;
-								State.LockState = ELockState::NotLocked;
-								State.LockUser = "";
-							}
+							FGitSourceControlModule::Get().GetProvider().Execute(ISourceControlOperation::Create<FGitLFSRefreshLocks>(), InCommand.Files);
 						}
 					}
 				}

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -749,7 +749,7 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 		const TArray<FString> ProjectDirs {FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
 										   FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
 		TMap<FString, FGitSourceControlState> UpdatedStates;
-		GitSourceControlUtils::RefreshLocks({}, InCommand.PathToRepositoryRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
+		GitSourceControlUtils::RefreshLocks(FGitSourceControlModule::GetEmptyStringArray(), InCommand.PathToRepositoryRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
 																			  ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
 		GitSourceControlUtils::RemoveRedundantErrors(InCommand, TEXT("' is outside repository"));

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -910,7 +910,7 @@ bool FGitResolveWorker::Execute( class FGitSourceControlCommand& InCommand )
 
 FName FGitLFSRefreshLocks::GetName() const
 {
-	return "Refresh Locks";
+	return "RefreshLocks";
 }
 
 FText FGitLFSRefreshLocks::GetInProgressString() const
@@ -920,7 +920,7 @@ FText FGitLFSRefreshLocks::GetInProgressString() const
 
 FName FGitRefreshLockStateWorker::GetName() const
 {
-	return "Refreshing locks";
+	return "RefreshingLocks";
 }
 
 bool FGitRefreshLockStateWorker::Execute(class FGitSourceControlCommand& InCommand)

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.cpp
@@ -177,7 +177,7 @@ bool FGitCheckOutWorker::Execute(FGitSourceControlCommand& InCommand)
 	}
 	else
 	{
-		FGitSourceControlModule::Get().GetProvider().Execute(ISourceControlOperation::Create<FGitLFSRefreshLocks>(), InCommand.Files);
+		InCommand.bCommandSuccessful &= GitSourceControlUtils::RefreshLocks(InCommand.Files, InCommand.PathToGitRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
 	}
 
 	return InCommand.bCommandSuccessful;
@@ -415,7 +415,7 @@ bool FGitCheckInWorker::Execute(FGitSourceControlCommand& InCommand)
 
 						if (!bUnlockSuccess)
 						{
-							FGitSourceControlModule::Get().GetProvider().Execute(ISourceControlOperation::Create<FGitLFSRefreshLocks>(), InCommand.Files);
+							InCommand.bCommandSuccessful &= GitSourceControlUtils::RefreshLocks(InCommand.Files, InCommand.PathToGitRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
 						}
 					}
 				}
@@ -654,7 +654,7 @@ bool FGitRevertWorker::Execute(FGitSourceControlCommand& InCommand)
 			}
 			else
 			{
-				FGitSourceControlModule::Get().GetProvider().Execute(ISourceControlOperation::Create<FGitLFSRefreshLocks>(), InCommand.Files);
+				InCommand.bCommandSuccessful &= GitSourceControlUtils::RefreshLocks(LockedFiles, InCommand.PathToGitRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
 			}
 		}
 	}
@@ -749,7 +749,7 @@ bool FGitFetchWorker::Execute(FGitSourceControlCommand& InCommand)
 		const TArray<FString> ProjectDirs {FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()),FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()),
 										   FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath())};
 		TMap<FString, FGitSourceControlState> UpdatedStates;
-		GitSourceControlUtils::RefreshLocks(InCommand.PathToRepositoryRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
+		GitSourceControlUtils::RefreshLocks({}, InCommand.PathToRepositoryRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
 		InCommand.bCommandSuccessful = GitSourceControlUtils::RunUpdateStatus(InCommand.PathToGitBinary, InCommand.PathToRepositoryRoot, InCommand.bUsingGitLfsLocking,
 																			  ProjectDirs, InCommand.ResultInfo.ErrorMessages, UpdatedStates);
 		GitSourceControlUtils::RemoveRedundantErrors(InCommand, TEXT("' is outside repository"));
@@ -907,67 +907,6 @@ bool FGitResolveWorker::Execute( class FGitSourceControlCommand& InCommand )
 		GitSourceControlUtils::CollectNewStates(UpdatedStates, States);
 	}
 
-	return InCommand.bCommandSuccessful;
-}
-
-FName FGitLFSRefreshLocks::GetName() const
-{
-	return "RefreshLocks";
-}
-
-FText FGitLFSRefreshLocks::GetInProgressString() const
-{
-	return LOCTEXT("SourceControl_RefreshLocks", "Fetching locks from server...");
-}
-
-FName FGitRefreshLockStateWorker::GetName() const
-{
-	return "RefreshingLocks";
-}
-
-bool FGitRefreshLockStateWorker::Execute(class FGitSourceControlCommand& InCommand)
-{
-	// Git LFS locks is a slow command - regardless of how many files are passed in
-	// it does get slower as you introduce more locks, but definitely not linearly, in local testing a repo with 7,500 files locked
-	// takes about twice as long as a repo with 1 lock, so there's additional overhead with status updates, but you very quickly pay more for
-	// refreshing specific files than you do for refreshing all files, so beyond 2 files we will just refresh the whole project state.
-	// We can re-assess this if it becomes problematic anyway.
-	const int LocksThresholdForFullRefresh = 2;
-	const FString& LockUser = FGitSourceControlModule::Get().GetProvider().GetLockUser();
-
-	if (!InCommand.Files.IsEmpty() && InCommand.Files.Num() < LocksThresholdForFullRefresh)
-	{
-		TArray<FString> FilesToRefresh = GitSourceControlUtils::RelativeFilenames(InCommand.Files, InCommand.PathToGitRoot);
-
-		TArray<FString> Parameters{ "-p" };
-		for (const FString& FilePath : FilesToRefresh)
-		{
-			const bool bLockCheckSucceeded = GitSourceControlUtils::RunLFSCommand(TEXT("locks"), InCommand.PathToGitRoot, InCommand.PathToGitBinary, Parameters, { FilePath }, InCommand.ResultInfo.InfoMessages, InCommand.ResultInfo.ErrorMessages);
-			InCommand.bCommandSuccessful &= bLockCheckSucceeded;
-			if (bLockCheckSucceeded)
-			{
-				FGitState& State = States.FindOrAdd(FilePath);
-				State.TreeState = ETreeState::Unset;
-				State.RemoteState = ERemoteState::Unset;
-				State.LockState = ELockState::NotLocked;
-				State.LockUser = "";
-
-				if (!InCommand.ResultInfo.InfoMessages.IsEmpty())
-				{
-					// The result of this call should contain only 1 entry, telling us who holds the lock, since we only asked for the lock owner of 1 file.
-					// project/path/to/file/filename    Jane Doe    id:####
-					check(InCommand.ResultInfo.InfoMessages.Num() == 1);
-					GitSourceControlUtils::FGitLfsLocksParser LockInfo(InCommand.PathToRepositoryRoot, InCommand.ResultInfo.InfoMessages.Last());
-					State.LockState = LockInfo.LockUser == LockUser ? ELockState::Locked : ELockState::LockedOther;
-					State.LockUser = LockInfo.LockUser;
-				}
-			}
-		}
-	}
-	else
-	{
-		InCommand.bCommandSuccessful = GitSourceControlUtils::RefreshLocks(InCommand.PathToRepositoryRoot, InCommand.PathToGitBinary, InCommand.ResultInfo.ErrorMessages, States);
-	}
 	return InCommand.bCommandSuccessful;
 }
 

--- a/Source/GitSourceControl/Private/GitSourceControlOperations.h
+++ b/Source/GitSourceControl/Private/GitSourceControlOperations.h
@@ -25,14 +25,6 @@ public:
 	bool bUpdateStatus = false;
 };
 
-class FGitLFSRefreshLocks : public ISourceControlOperation
-{
-	// ISourceControlOperation interface
-	virtual FName GetName() const override;
-
-	virtual FText GetInProgressString() const override;
-};
-
 class FGitSourceControlWorker : public IGitSourceControlWorker
 {
 public:
@@ -189,14 +181,5 @@ public:
 	
 	/** Temporary states for results */
 	TMap<const FString, FGitState> States;
-};
-
-class FGitRefreshLockStateWorker : public FGitSourceControlWorker
-{
-public:
-	virtual ~FGitRefreshLockStateWorker() {}
-	// IGitSourceControlWorker interface
-	virtual FName GetName() const override;
-	virtual bool Execute(class FGitSourceControlCommand& InCommand) override;
 };
 #endif

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -191,7 +191,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 
 				if (GitSourceControlUtils::CollectNewStates(States, Results))
 				{
-					GitSourceControlUtils::RefreshLocks({}, PathToRepositoryRoot, PathToGitBinary, StatusErrorMessages, Results);
+					GitSourceControlUtils::RefreshLocks(FGitSourceControlModule::GetEmptyStringArray(), PathToRepositoryRoot, PathToGitBinary, StatusErrorMessages, Results);
 					GitSourceControlUtils::UpdateCachedStates(Results);
 				}
 				Runner = new FGitSourceControlRunner();

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -191,7 +191,7 @@ void FGitSourceControlProvider::CheckRepositoryStatus()
 
 				if (GitSourceControlUtils::CollectNewStates(States, Results))
 				{
-					GitSourceControlUtils::RefreshLocks(PathToRepositoryRoot, PathToGitBinary, StatusErrorMessages, Results);
+					GitSourceControlUtils::RefreshLocks({}, PathToRepositoryRoot, PathToGitBinary, StatusErrorMessages, Results);
 					GitSourceControlUtils::UpdateCachedStates(Results);
 				}
 				Runner = new FGitSourceControlRunner();

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1461,7 +1461,7 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	OutErrorMessages.Append(ErrorMessages);
 }
 
-bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallback, TArray<FString>& OutErrorMessages, TMap<const FString, FGitState>& OutStates)
+bool RefreshLocks(const TArray<FString>& FilesToRefresh, const FString& InRepositoryRoot, const FString& GitBinaryFallback, TArray<FString>& OutErrorMessages, TMap<const FString, FGitState>& OutStates)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(GitSourceControlUtils::RefreshLocks);
 
@@ -1472,42 +1472,87 @@ bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallb
 	static FCriticalSection ConcurrencyProtection;
 	FScopeLock Lock(&ConcurrencyProtection);
 	
-	TArray<FString> Results;
-	bool bResult = RunLFSCommand(TEXT("locks"), InRepositoryRoot, GitBinaryFallback, FGitSourceControlModule::GetEmptyStringArray(), FGitSourceControlModule::GetEmptyStringArray(),
-							Results, OutErrorMessages);
+	// Git LFS locks is a slow command - regardless of how many files are passed in
+	// it does get slower as you introduce more locks, but definitely not linearly, in local testing a repo with 7,500 files locked
+	// takes about twice as long as a repo with 1 lock, so there's additional overhead with status updates, but you very quickly pay more for
+	// refreshing specific files than you do for refreshing all files, so beyond 2 files we will just refresh the whole project state.
+	// We can re-assess this if it becomes problematic anyway.
+	const int LocksThresholdForFullRefresh = 2;
+	const FString& LockUser = FGitSourceControlModule::Get().GetProvider().GetLockUser();
 
-	// If we can't connect to server, fall back to our cached lock state - there's no guarantee that the state hasn't changed on the server, but it's better than not showing locks at all.
-	if (!bResult)
-	{
-		bResult = RunLFSCommand(TEXT("locks"), InRepositoryRoot, GitBinaryFallback, { TEXT("--cached") }, FGitSourceControlModule::GetEmptyStringArray(),
-			Results, OutErrorMessages);
-	}
+	bool bResult = true;
 
-	if (bResult)
+	if (!FilesToRefresh.IsEmpty() && FilesToRefresh.Num() < LocksThresholdForFullRefresh)
 	{
-		// Reset all lock states to be not locked, then override any which are locked to reflect that
-		for (auto& State : OutStates)
+		TArray<FString> RelativeFiles = GitSourceControlUtils::RelativeFilenames(FilesToRefresh, InRepositoryRoot);
+
+		TArray<FString> Parameters{ "-p" };
+		for (const FString& FilePath : RelativeFiles)
 		{
-			if (State.Value.LockState != ELockState::NotLockable)
+			TArray<FString> Responses;
+			const bool bLockCheckSucceeded = GitSourceControlUtils::RunLFSCommand(TEXT("locks"), InRepositoryRoot, GitBinaryFallback, Parameters, { FilePath }, Responses, OutErrorMessages);
+			bResult &= bLockCheckSucceeded;
+			if (bLockCheckSucceeded)
 			{
-				State.Value.LockState = ELockState::NotLocked;
+				FGitState& State = OutStates.FindOrAdd(FilePath);
+				State.TreeState = ETreeState::Unset;
+				State.RemoteState = ERemoteState::Unset;
+				State.LockState = ELockState::NotLocked;
+				State.LockUser = "";
+
+				if (!Responses.IsEmpty())
+				{
+					// The result of this call should contain only 1 entry, telling us who holds the lock, since we only asked for the lock owner of 1 file.
+					// project/path/to/file/filename    Jane Doe    id:####
+					check(Responses.Num() == 1);
+					GitSourceControlUtils::FGitLfsLocksParser LockInfo(InRepositoryRoot, Responses.Last());
+					State.LockState = LockInfo.LockUser == LockUser ? ELockState::Locked : ELockState::LockedOther;
+					State.LockUser = LockInfo.LockUser;
+				}
 			}
 		}
+	}
+	else
+	{
 
-		const FString& LfsUserName = FGitSourceControlModule::Get().GetProvider().GetLockUser();
+		TArray<FString> Results;
+		bResult = RunLFSCommand(TEXT("locks"), InRepositoryRoot, GitBinaryFallback, FGitSourceControlModule::GetEmptyStringArray(), FGitSourceControlModule::GetEmptyStringArray(),
+			Results, OutErrorMessages);
 
-		for (const FString& Result : Results)
+		// If we can't connect to server, fall back to our cached lock state - there's no guarantee that the state hasn't changed on the server, but it's better than not showing locks at all.
+		if (!bResult)
 		{
-			FGitLfsLocksParser LockFile(InRepositoryRoot, Result);
-#if UE_BUILD_DEBUG && GIT_DEBUG_STATUS
-			UE_LOG(LogSourceControl, Log, TEXT("LockedFile(%s, %s)"), *LockFile.LocalFilename, *LockFile.LockUser);
-#endif	
-			FGitState& State = OutStates.FindOrAdd(LockFile.LocalFilename);
+			bResult = RunLFSCommand(TEXT("locks"), InRepositoryRoot, GitBinaryFallback, { TEXT("--cached") }, FGitSourceControlModule::GetEmptyStringArray(),
+				Results, OutErrorMessages);
+		}
 
-			State.LockState = LockFile.LockUser == LfsUserName ? ELockState::Locked : ELockState::LockedOther;
-			State.LockUser = LockFile.LockUser;
+		if (bResult)
+		{
+			// Reset all lock states to be not locked, then override any which are locked to reflect that
+			for (auto& State : OutStates)
+			{
+				if (State.Value.LockState != ELockState::NotLockable)
+				{
+					State.Value.LockState = ELockState::NotLocked;
+				}
+			}
+
+			const FString& LfsUserName = FGitSourceControlModule::Get().GetProvider().GetLockUser();
+
+			for (const FString& Result : Results)
+			{
+				FGitLfsLocksParser LockFile(InRepositoryRoot, Result);
+#if UE_BUILD_DEBUG && GIT_DEBUG_STATUS
+				UE_LOG(LogSourceControl, Log, TEXT("LockedFile(%s, %s)"), *LockFile.LocalFilename, *LockFile.LockUser);
+#endif	
+				FGitState& State = OutStates.FindOrAdd(LockFile.LocalFilename);
+
+				State.LockState = LockFile.LockUser == LfsUserName ? ELockState::Locked : ELockState::LockedOther;
+				State.LockUser = LockFile.LockUser;
+			}
 		}
 	}
+
 
 	return bResult;
 }

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -359,6 +359,7 @@ bool CollectNewStates(const TArray<FString>& InFiles, TMap<const FString, FGitSt
 /**
 	* Run "git lfs locks" to update lock states
 	*
+	* @param	FilesToRefresh		The list of files to refresh the locks for (Empty to refresh all locks)
 	* @param	InRepositoryRoot	The Git repository from where to run the command - usually the Game directory
 	* @param	GitBinaryFallBack	The Git binary fallback path
 	* @param	OutErrorMessages	Any errors (from StdErr) as an array per-line

--- a/Source/GitSourceControl/Public/GitSourceControlUtils.h
+++ b/Source/GitSourceControl/Public/GitSourceControlUtils.h
@@ -364,7 +364,7 @@ bool CollectNewStates(const TArray<FString>& InFiles, TMap<const FString, FGitSt
 	* @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
 	* @param	OutStates			Map of updated lock states
 */
-bool RefreshLocks(const FString& InRepositoryRoot, const FString& GitBinaryFallBack, TArray<FString>& OutErrorMessages, TMap<const FString, FGitState>& OutStates);
+bool RefreshLocks(const TArray<FString>& FilesToRefresh, const FString& InRepositoryRoot, const FString& GitBinaryFallBack, TArray<FString>& OutErrorMessages, TMap<const FString, FGitState>& OutStates);
 
 /**
  * Gets locks from state cache


### PR DESCRIPTION
- When committing files, only locked files had their state updated, so newly added files would be in an incorrect state in the engine
- When a git command failed we were running a "RefreshLocks" action which wasn't actually doing anything