### PR TITLE
Update readonly state on added and modified files

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2155,12 +2155,14 @@ bool UpdateCachedStates(const TMap<const FString, FGitState>& InResults)
 			{
 				continue;
 			}
+
 			// Git LFS default behavior is to mark all lockable files which aren't locked by the current user as read-only
 			// This happens in the LFS post-checkout hook script, which makes our 'mark writable' and 'added' files revert to readonly
 			if (NewState.FileState == EFileState::Added || NewState.FileState == EFileState::Modified)
 			{
 				FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*State->GetFilename(), false);
 			}
+
 			State->State.FileState = NewState.FileState;
 		}
 		if (NewState.TreeState != ETreeState::Unset)

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1544,8 +1544,6 @@ bool RefreshLocks(const TArray<FString>& FilesToRefresh, const FString& InReposi
 				}
 			}
 
-			const FString& LfsUserName = FGitSourceControlModule::Get().GetProvider().GetLockUser();
-
 			for (const FString& Result : Results)
 			{
 				FGitLfsLocksParser LockFile(InRepositoryRoot, Result);

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2155,6 +2155,12 @@ bool UpdateCachedStates(const TMap<const FString, FGitState>& InResults)
 			{
 				continue;
 			}
+			// Git LFS default behavior is to mark all lockable files which aren't locked by the current user as read-only
+			// This happens in the LFS post-checkout hook script, which makes our 'mark writable' and 'added' files revert to readonly
+			if (NewState.FileState == EFileState::Added || NewState.FileState == EFileState::Modified)
+			{
+				FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*State->GetFilename(), false);
+			}
 			State->State.FileState = NewState.FileState;
 		}
 		if (NewState.TreeState != ETreeState::Unset)


### PR DESCRIPTION
The default Git LFS behavior marks all tracked 'lockable' files as ReadOnly if they're not checked out by the current user, this includes files marked for add
If you add a new file, and then pull from git, your new file becomes ReadOnly, and that's always a bad time

This behavior can be overridden on a per-machine basis with a git config setting, but the alternative option is that it just doesn't mark files as ReadOnly ever, which also doesn't gel with our workflow - so the simplest solution for us is to un-ReadOnly files in engine which are detected as added or modified