### PR TITLE
Disable changelists and the additional "Submit Content" button in UEGitPlugin

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -538,19 +538,21 @@ void FGitSourceControlMenu::AddMenuExtension(FToolMenuSection& Builder)
 void FGitSourceControlMenu::AddMenuExtension(FMenuBuilder& Builder)
 #endif
 {
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
-	// UE 5.6 removed the submit content button, so re-create one here
-	Builder.AddMenuEntry(
-		"CommitAndPush",
-		LOCTEXT("GitCommit",				"Submit Content"),
-		LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
-		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
-		FUIAction(
-			FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
-			FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
-		)
-	);
-#endif
+	// [DIVERGENCE]	TECH-296 Disable the "View Changes" button from Source Control menu
+// #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
+// 	// UE 5.6 removed the submit content button, so re-create one here
+// 	Builder.AddMenuEntry(
+// 		"CommitAndPush",
+// 		LOCTEXT("GitCommit",				"Submit Content"),
+// 		LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
+// 		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
+// 		FUIAction(
+// 			FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
+// 			FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
+// 		)
+// 	);
+// #endif
+	// [END DIVERGENCE]
 	
 	Builder.AddMenuEntry(
 #if ENGINE_MAJOR_VERSION >= 5

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -564,7 +564,10 @@ bool FGitSourceControlProvider::UsesLocalReadOnlyState() const
 
 bool FGitSourceControlProvider::UsesChangelists() const
 {
-	return true;
+	// [DIVERGENCE]	TECH-296 Disable the "View Changes" button from Source Control menu
+	//return true;
+	return false;
+	// [END DIVERGENCE]
 }
 
 bool FGitSourceControlProvider::UsesCheckout() const
@@ -597,7 +600,10 @@ bool FGitSourceControlProvider::AllowsDiffAgainstDepot() const
 
 bool FGitSourceControlProvider::UsesUncontrolledChangelists() const
 {
-	return true;
+	// [DIVERGENCE]	TECH-296 Disable the "View Changes" button from Source Control menu
+	//return true;
+	return false;
+	// [END DIVERGENCE]
 }
 
 bool FGitSourceControlProvider::UsesSnapshots() const


### PR DESCRIPTION
The the UE git implementation doesn't support changelists because that isn't a feature that git supports. Recently a feature was added to UEGitPlugin that fakes changelists so changes, specifically One File Per Actor changes, can be staged and committed via an external git client. As we have auto stage enabled it renders this functionality broken.

Because this is default enabled behaviour in the UEGitPlugin they had to add a custom "Submit Content" button as UE hides it if changelists are enabled. By disabling changelists we hide the "View Changes" menu item but gain the built in "Submit Content" button. We need to disable the "Submit Content" button added in the UEGitPlugin so we don't double up.