### PR TITLE
Always call SetReadOnly on added/writable files

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -2185,17 +2185,17 @@ bool UpdateCachedStates(const TMap<const FString, FGitState>& InResults)
 		const FGitState& NewState = Pair.Value;
 		if (NewState.FileState != EFileState::Unset)
 		{
-			// Invalid transition
-			if (NewState.FileState == EFileState::Added && !State->IsUnknown() && !State->CanAdd())
-			{
-				continue;
-			}
-
 			// Git LFS default behavior is to mark all lockable files which aren't locked by the current user as read-only
 			// This happens in the LFS post-checkout hook script, which makes our 'mark writable' and 'added' files revert to readonly
 			if (NewState.FileState == EFileState::Added || NewState.FileState == EFileState::Modified)
 			{
 				FPlatformFileManager::Get().GetPlatformFile().SetReadOnly(*State->GetFilename(), false);
+			}
+			
+			// Invalid transition
+			if (NewState.FileState == EFileState::Added && !State->IsUnknown() && !State->CanAdd())
+			{
+				continue;
 			}
 
 			State->State.FileState = NewState.FileState;


### PR DESCRIPTION
Added files enter the "invalid transition" block. When files are created they are "ReadOnly: False" but when a git lfs operation happens (eg. revert) it will mark all files on disk as "ReadOnly: True" but since we never get to the code block to set "ReadOnly: False" you just have a Bad Time and can't save the file again without updating the file on disk.