### PR TITLE
Updated plugin to show a popup Submit Content is clicked and not at latest revision

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -265,7 +265,7 @@ void FGitSourceControlMenu::CommitClicked()
 		{
 		case EAppReturnType::Yes:
 			{
-				FSourceControlWindows::ChoosePackagesToCheckIn();
+				FSourceControlWindows::ChoosePackagesToCheckIn(nullptr);
 			}
 			break;
 		case EAppReturnType::No:
@@ -279,7 +279,7 @@ void FGitSourceControlMenu::CommitClicked()
 	}
 	else
 	{
-		FSourceControlWindows::ChoosePackagesToCheckIn();
+		FSourceControlWindows::ChoosePackagesToCheckIn(nullptr);
 	}
 }
 

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -251,7 +251,34 @@ void FGitSourceControlMenu::CommitClicked()
 	}
 	
 	FLevelEditorModule & LevelEditorModule = FModuleManager::Get().LoadModuleChecked<FLevelEditorModule>("LevelEditor");
-	FSourceControlWindows::ChoosePackagesToCheckIn(nullptr);
+	
+	ISourceControlProvider& SourceControlProvider = ISourceControlModule::Get().GetProvider();
+	const TOptional<bool> bAtLatestRevision = SourceControlProvider.IsAtLatestRevision();
+	if (bAtLatestRevision.IsSet() && !bAtLatestRevision.GetValue())
+	{
+		const FText InfoMessage = FText::FromString(TEXT("Your local repository is not at the latest revision. You will need to close the editor and pull before you can submit your changes."));
+		const EAppReturnType::Type Selection = FMessageDialog::Open(EAppMsgCategory::Warning, EAppMsgType::YesNo, InfoMessage);
+
+		switch (Selection)
+		{
+		case EAppReturnType::Yes:
+			{
+				FSourceControlWindows::ChoosePackagesToCheckIn();
+			}
+			break;
+		case EAppReturnType::No:
+			[[fallthrough]];
+		case EAppReturnType::Cancel:
+			// Do nothing
+			break;
+		default:
+			checkf(false, TEXT("Unexpected selection from not at latest revision dialog"));
+		}
+	}
+	else
+	{
+		FSourceControlWindows::ChoosePackagesToCheckIn();
+	}
 }
 
 void FGitSourceControlMenu::PushClicked()
@@ -538,22 +565,17 @@ void FGitSourceControlMenu::AddMenuExtension(FToolMenuSection& Builder)
 void FGitSourceControlMenu::AddMenuExtension(FMenuBuilder& Builder)
 #endif
 {
-	// UE 5.6 doesn't show the Submit Content button if changelists are enabled
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6
-	const FGitSourceControlProvider& Provider = FGitSourceControlModule::Get().GetProvider();
-	if (Provider.UsesChangelists())
-	{
-		Builder.AddMenuEntry(
-			"CommitAndPush",
-			LOCTEXT("GitCommit",				"Submit Content"),
-			LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
-			FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
-			FUIAction(
-				FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
-				FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
-			)
-		);
-	}
+	Builder.AddMenuEntry(
+		"CommitAndPush",
+		LOCTEXT("GitCommit",				"Submit Content"),
+		LOCTEXT("GitPushTooltip",		"Opens a dialog with check in options for content and levels."),
+		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Submit"),
+		FUIAction(
+			FExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CommitClicked),
+			FCanExecuteAction::CreateRaw(this, &FGitSourceControlMenu::CanCommit)
+		)
+	);
 #endif
 	
 	Builder.AddMenuEntry(

--- a/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlMenu.cpp
@@ -256,8 +256,10 @@ void FGitSourceControlMenu::CommitClicked()
 	const TOptional<bool> bAtLatestRevision = SourceControlProvider.IsAtLatestRevision();
 	if (bAtLatestRevision.IsSet() && !bAtLatestRevision.GetValue())
 	{
-		const FText InfoMessage = FText::FromString(TEXT("Your local repository is not at the latest revision. You will need to close the editor and pull before you can submit your changes."));
-		const EAppReturnType::Type Selection = FMessageDialog::Open(EAppMsgCategory::Warning, EAppMsgType::YesNo, InfoMessage);
+		static const FText Message = FText::FromString(TEXT("Your local repository is not at the latest revision. "
+			"You will need to close the editor and pull before you can submit your changes."
+			"\n\nOpen submission window anyway?"));
+		const EAppReturnType::Type Selection = FMessageDialog::Open(EAppMsgCategory::Warning, EAppMsgType::YesNo, Message);
 
 		switch (Selection)
 		{

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -583,7 +583,18 @@ bool FGitSourceControlProvider::UsesFileRevisions() const
 
 TOptional<bool> FGitSourceControlProvider::IsAtLatestRevision() const
 {
-	return TOptional<bool>();
+	TArray<FString> ErrorMessages;
+	int NumRevisionsBehind = 0;
+	const bool bSuccess = GitSourceControlUtils::GetNumRevisionsBehindOrigin(PathToGitBinary, PathToRepositoryRoot, NumRevisionsBehind, ErrorMessages);
+	
+	if (bSuccess)
+	{
+		return TOptional<bool>(NumRevisionsBehind == 0);
+	}
+	else
+	{
+		return TOptional<bool>();
+	}
 }
 
 TOptional<int> FGitSourceControlProvider::GetNumLocalChanges() const


### PR DESCRIPTION
Added implementation of IsAtLatestRevision in GitSourceControlProvider
Re-enabled the plugin's Submit Content button
Added a yes/no popup when Submit Content is clicked and we are not at the latest revision