### PR TITLE
Update state branch handling to support sorting branches into hierarc…

### DIFF
--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -913,8 +913,8 @@ void FGitSourceControlProvider::GetStatusBranchesAtHierarchyIndex(int32 Hierarch
 	for (const FString& Match : Matches)
 	{
 		FString Trimmed = Match.TrimStartAndEnd();
-		// Lower wildcard matches could be broad 'catch all' type matches, and can include branches from lower states
-		// ensure that the branches returned here are actually for our index.
+		// Higher index wildcard matches could be broad 'catch all' type matches, and can include branches from lower states
+		// filter out any branches which would be matched by a lower index
 		if (GetStateBranchIndex(Trimmed) != HierarchyIndex)
 		{
 			continue;

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -913,6 +913,12 @@ void FGitSourceControlProvider::GetStatusBranchesAtHierarchyIndex(int32 Hierarch
 	for (const FString& Match : Matches)
 	{
 		FString Trimmed = Match.TrimStartAndEnd();
+		// Lower wildcard matches could be broad 'catch all' type matches, and can include branches from lower states
+		// ensure that the branches returned here are actually for our index.
+		if (GetStateBranchIndex(Trimmed) != HierarchyIndex)
+		{
+			continue;
+		}
 		// Git branch --remotes can return a synthetic "origin/HEAD -> origin/main" entry — skip it.
 		if (!Trimmed.StartsWith("origin/HEAD"))
 		{
@@ -939,16 +945,16 @@ int32 FGitSourceControlProvider::GetStatusBranchHierarchyIndex(const FString& Br
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
 bool FGitSourceControlProvider::GetStateBranchAtIndex(int32 BranchIndex, FString& OutBranchName) const
 {
-	// Return the first status branch that sits at the requested hierarchy level.
-	for (const FString& Branch : GetStatusBranchNames())
+	TSet<FString> BranchNames;
+	GetStatusBranchesAtHierarchyIndex(BranchIndex, BranchNames);
+	if (BranchNames.Num() == 0)
 	{
-		if (GetStatusBranchHierarchyIndex(Branch) == BranchIndex)
-		{
-			OutBranchName = Branch;
-			return true;
-		}
+		return false;
 	}
-	return false;
+	
+	ensure(BranchNames.Num() == 1);
+	OutBranchName = *BranchNames.begin();
+	return true;
 }
 #endif
 

--- a/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlProvider.cpp
@@ -901,15 +901,52 @@ void FGitSourceControlProvider::RegisterStateBranches(const TArray<FString>& Bra
 	StatusBranchNamePatternsInternal = BranchNames;
 }
 
+void FGitSourceControlProvider::GetStatusBranchesAtHierarchyIndex(int32 HierarchyIndex, TSet<FString>& OutBranches) const
+{
+	if (!StatusBranchNamePatternsInternal.IsValidIndex(HierarchyIndex))
+	{
+		return;
+	}
+
+	TArray<FString> Matches;
+	GitSourceControlUtils::GetRemoteBranchesWildcard(PathToGitBinary, PathToRepositoryRoot, StatusBranchNamePatternsInternal[HierarchyIndex], Matches);
+	for (const FString& Match : Matches)
+	{
+		FString Trimmed = Match.TrimStartAndEnd();
+		// Git branch --remotes can return a synthetic "origin/HEAD -> origin/main" entry — skip it.
+		if (!Trimmed.StartsWith("origin/HEAD"))
+		{
+			OutBranches.Add(Trimmed);
+		}
+	}
+}
+
+int32 FGitSourceControlProvider::GetStatusBranchHierarchyIndex(const FString& BranchNameToCheck) const
+{
+	// Each entry in StatusBranchNamePatternsInternal is a wildcard pattern representing one level of the branch hierarchy.
+	// Pattern 0 = most stable (e.g. release branches), higher indices = less stable (e.g. feature branches).
+	// We return the index of the first pattern that the branch name matches.
+	for (int32 i = 0; i < StatusBranchNamePatternsInternal.Num(); i++)
+	{
+		if (BranchNameToCheck.MatchesWildcard(StatusBranchNamePatternsInternal[i]))
+		{
+			return i;
+		}
+	}
+	return INDEX_NONE;
+}
+
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 7
 bool FGitSourceControlProvider::GetStateBranchAtIndex(int32 BranchIndex, FString& OutBranchName) const
 {
-	auto StatusBranchNames = GetStatusBranchNames();
-
-	if (BranchIndex >= 0 && BranchIndex < StatusBranchNames.Num())
+	// Return the first status branch that sits at the requested hierarchy level.
+	for (const FString& Branch : GetStatusBranchNames())
 	{
-		OutBranchName = StatusBranchNames[BranchIndex];
-		return true;
+		if (GetStatusBranchHierarchyIndex(Branch) == BranchIndex)
+		{
+			OutBranchName = Branch;
+			return true;
+		}
 	}
 	return false;
 }
@@ -917,52 +954,43 @@ bool FGitSourceControlProvider::GetStateBranchAtIndex(int32 BranchIndex, FString
 
 int32 FGitSourceControlProvider::GetStateBranchIndex(const FString& StateBranchName) const
 {
-	// How do state branches indices work?
-	// Order matters. Lower values are lower in the hierarchy, i.e., changes from higher branches get automatically merged down.
-	// The higher branch is, the stabler it is, and has changes manually promoted up.
+	// How do state branch indices work?
+	// Index 0 = most stable (e.g. release branches). Higher indices = less stable (e.g. feature branches).
+	// Each entry in StatusBranchNamePatternsInternal is a wildcard pattern defining one level, so multiple
+	// concrete branches (e.g. origin/release/1.0 and origin/release/2.0) can share the same hierarchy level.
+	// Changes are promoted upward (toward lower indices) manually, and automatically merged down (toward higher indices).
 
-	// Check if we are checking the index of the current branch
 	// UE uses FEngineVersion for the current branch name because of UEGames setup, but we want to handle otherwise for Git repos.
-	auto StatusBranchNames = GetStatusBranchNames();
 	if (StateBranchName == FEngineVersion::Current().GetBranch())
 	{
-		const int32 CurrentBranchStatusIndex = StatusBranchNames.IndexOfByKey(BranchName);
-		const bool bCurrentBranchInStatusBranches = CurrentBranchStatusIndex != INDEX_NONE;
-		// If the user's current branch is tracked as a status branch, give the proper index
-		if (bCurrentBranchInStatusBranches)
+		const int32 CurrentBranchHierarchyIndex = GetStatusBranchHierarchyIndex(BranchName);
+		if (CurrentBranchHierarchyIndex != INDEX_NONE)
 		{
-			return CurrentBranchStatusIndex;
+			return CurrentBranchHierarchyIndex;
 		}
-		// If the current branch is not a status branch, make it the highest branch
-		// This is semantically correct, since if a branch is not marked as a status branch
-		// it merges changes in a similar fashion to the highest status branch, i.e. manually promotes them
-		// based on the user merging those changes in. and these changes always get merged from even the highest point
-		// of the stream. i.e, promoted/stable changes are always up for consumption by this branch.
+		// If the current branch is not a status branch, treat it as the highest branch.
+		// It merges changes in a similar fashion to the highest status branch — manually promoting them
+		// based on the user merging those changes in — and promoted/stable changes are always up for consumption.
 		return INT32_MAX;
 	}
 
-	// If we're not checking the current branch, then we don't need to do special handling.
-	// If it is not a status branch, there is no message
-	return StatusBranchNames.IndexOfByKey(StateBranchName);
+	return GetStatusBranchHierarchyIndex(StateBranchName);
 }
 
 TArray<FString> FGitSourceControlProvider::GetStatusBranchNames() const
 {
-	TArray<FString> StatusBranches;
-	if(PathToGitBinary.IsEmpty() || PathToRepositoryRoot.IsEmpty())
-		return StatusBranches;
-	
-	for (int i = 0; i < StatusBranchNamePatternsInternal.Num(); i++)
+	if (PathToGitBinary.IsEmpty() || PathToRepositoryRoot.IsEmpty())
 	{
-		TArray<FString> Matches;
-		bool bResult = GitSourceControlUtils::GetRemoteBranchesWildcard(PathToGitBinary, PathToRepositoryRoot, StatusBranchNamePatternsInternal[i], Matches);
-		Algo::Transform(Matches, StatusBranches, [](const FString& Branch) { return Branch.TrimStartAndEnd(); });
+		return {};
 	}
-	
-	// Git branch --remotes will return a branch in the format "origin/HEAD -> origin/main" in the list of branches...
-	StatusBranches.SetNum(Algo::RemoveIf(StatusBranches, [](const FString& Branch) { return Branch.StartsWith("origin/HEAD"); }));
 
-	return StatusBranches;
+	TSet<FString> BranchSet;
+	for (int32 i = 0; i < StatusBranchNamePatternsInternal.Num(); i++)
+	{
+		GetStatusBranchesAtHierarchyIndex(i, BranchSet);
+	}
+
+	return BranchSet.Array();
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1361,9 +1361,6 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 		return;
 	}
 	FGitSourceControlProvider& Provider = GitSourceControl->GetProvider();
-	const TArray<FString> StatusBranches = Provider.GetStatusBranchNames();
-
-	TSet<FString> BranchesToDiff{ StatusBranches };
 
 	bool bDiffAgainstRemoteCurrent = false;
 
@@ -1373,8 +1370,34 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	{
 		// We have a valid remote, so diff against it.
 		bDiffAgainstRemoteCurrent = true;
-		// Ensure that the remote branch is in there.
+	}
+
+	// Determine the current branch's position in the status branch hierarchy.
+	// Index 0 = most stable (e.g. release branches). Higher indices = less stable (e.g. feature branches).
+	// Multiple concrete branches can share a hierarchy level via wildcard patterns.
+	// If the current branch does not match any pattern it is a non-status branch and we
+	// include all status branches in the diff (we cannot determine what is "1 above" it).
+	const int32 CurrentBranchHierarchyIndex = Provider.GetStatusBranchHierarchyIndex(CurrentBranchName);
+	const bool bCurrentBranchIsStatusBranch = CurrentBranchHierarchyIndex != INDEX_NONE;
+
+	// Build the diff set: always include the current branch's remote (for NotAtHead detection).
+	// For status branches, only include those at the same hierarchy level or 1 level more stable (index - 1).
+	// Branches further away are too removed to surface as a relevant blocking state.
+	TSet<FString> BranchesToDiff;
+	if (bDiffAgainstRemoteCurrent)
+	{
 		BranchesToDiff.Add(CurrentBranchName);
+	}
+	
+	if (!bCurrentBranchIsStatusBranch)
+    {
+    	// Cannot determine the relative position of a non-status branch, so include all status branches.
+    	BranchesToDiff.Add(Provider.GetStatusBranchNames());
+    }
+	else
+	{
+		Provider.GetStatusBranchesAtHierarchyIndex(CurrentBranchHierarchyIndex, BranchesToDiff);
+		Provider.GetStatusBranchesAtHierarchyIndex(CurrentBranchHierarchyIndex-1, BranchesToDiff);
 	}
 
 	if (!BranchesToDiff.Num())
@@ -1428,7 +1451,7 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 			// Status Branches may not be initialized because they're not in use by the project. They can also be not initilaized in some other quirky circumstances
 			// eg. When running multi client / dedicated server in editor without running them under the same process, those game instances will run as an editor instance
 			// which means editor plugins are enabled and running, but they don't run UnrealEdEngine, so the status branches are not initialized.
-			if (StatusBranches.Num() > 0)
+			if (BranchesToDiff.Num() > 1)
 			{
 				// Check if the files state in the branch in which is changed is actually different from compared branch
 				// This opens files for edit if they were modified in another branch but have since been reverted back to state in status.
@@ -1475,6 +1498,8 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 		Intersection.Reset();
 	}
 
+	int CurrentBranchStateIndex = Provider.GetStateBranchIndex(CurrentBranchName);
+	
 	for (const auto& NewFile : NewerFiles)
 	{
 		if (FGitSourceControlState* FileState = OutStates.Find(NewFile.Key))

--- a/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
+++ b/Source/GitSourceControl/Private/GitSourceControlUtils.cpp
@@ -1378,7 +1378,6 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 	// If the current branch does not match any pattern it is a non-status branch and we
 	// include all status branches in the diff (we cannot determine what is "1 above" it).
 	const int32 CurrentBranchHierarchyIndex = Provider.GetStatusBranchHierarchyIndex(CurrentBranchName);
-	const bool bCurrentBranchIsStatusBranch = CurrentBranchHierarchyIndex != INDEX_NONE;
 
 	// Build the diff set: always include the current branch's remote (for NotAtHead detection).
 	// For status branches, only include those at the same hierarchy level or 1 level more stable (index - 1).
@@ -1389,16 +1388,10 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 		BranchesToDiff.Add(CurrentBranchName);
 	}
 	
-	if (!bCurrentBranchIsStatusBranch)
-    {
-    	// Cannot determine the relative position of a non-status branch, so include all status branches.
-    	BranchesToDiff.Add(Provider.GetStatusBranchNames());
-    }
-	else
-	{
-		Provider.GetStatusBranchesAtHierarchyIndex(CurrentBranchHierarchyIndex, BranchesToDiff);
-		Provider.GetStatusBranchesAtHierarchyIndex(CurrentBranchHierarchyIndex-1, BranchesToDiff);
-	}
+	// We only care about changes to branches at the same level as us, or one level up
+	// Our branches always merge up 1 index, and then automerge down.
+	Provider.GetStatusBranchesAtHierarchyIndex(CurrentBranchHierarchyIndex, BranchesToDiff);
+	Provider.GetStatusBranchesAtHierarchyIndex(CurrentBranchHierarchyIndex-1, BranchesToDiff);
 
 	if (!BranchesToDiff.Num())
 	{
@@ -1497,8 +1490,6 @@ void CheckRemote(const FString& InPathToGitBinary, const FString& InRepositoryRo
 		DiffResults.Reset();
 		Intersection.Reset();
 	}
-
-	int CurrentBranchStateIndex = Provider.GetStateBranchIndex(CurrentBranchName);
 	
 	for (const auto& NewFile : NewerFiles)
 	{

--- a/Source/GitSourceControl/Public/GitSourceControlProvider.h
+++ b/Source/GitSourceControl/Public/GitSourceControlProvider.h
@@ -212,6 +212,19 @@ public:
 	const FString& GetRemoteBranchName() const { return RemoteBranchName; }
 
 	TArray<FString> GetStatusBranchNames() const;
+
+	/**
+	 * Returns the hierarchy level for a branch by matching it against the registered status branch patterns.
+	 * Each pattern in StatusBranchNamePatternsInternal represents one hierarchy level (index 0 = most stable, e.g. release branches).
+	 * Returns the index of the first matching pattern, or INDEX_NONE if no pattern matches.
+	 */
+	int32 GetStatusBranchHierarchyIndex(const FString& BranchName) const;
+
+	/**
+	 * Appends all status branches that sit at the given hierarchy level into OutBranches.
+	 * Intended to be called multiple times to accumulate branches across adjacent levels.
+	 */
+	void GetStatusBranchesAtHierarchyIndex(int32 HierarchyIndex, TSet<FString>& OutBranches) const;
 	
 	/** Indicates editor binaries are to be updated upon next sync */
 	bool bPendingRestart;


### PR DESCRIPTION
…hies based on wildcard match rather than having all branches get their own index, and filter the branches to diff for modified in other branches to only 1 level of separation (upwards), this allows us to have release branches ignored when doing work in branches made from main, and main branches ignored when working in branches from release, effectively giving us separate work streams which can knowingly be divered